### PR TITLE
Add useExternalWithApp

### DIFF
--- a/src/Node/Express/App.purs
+++ b/src/Node/Express/App.purs
@@ -2,7 +2,7 @@ module Node.Express.App
     ( AppM()
     , App()
     , listenHttp, listenHttps, apply
-    , use, useExternal, useAt, useOnParam, useOnError
+    , use, useExternal, useExternalWithApp, useAt, useOnParam, useOnError
     , getProp, setProp
     , http, get, post, put, delete, all
     ) where
@@ -87,6 +87,13 @@ use middleware = AppM \app ->
 useExternal :: forall e. Fn3 Request Response (ExpressM e Unit) (ExpressM e Unit) -> App e
 useExternal fn = AppM \app ->
     runFn2 _useExternal app fn
+
+-- | Use any function as middleware, passing the current app to
+-- | be decorated by the middleware.
+useExternalWithApp :: forall e.
+ (Application -> Fn3 Request Response (ExpressM e Unit) (ExpressM e Unit)) -> App e
+useExternalWithApp fn = AppM \app ->
+   runFn2 _useExternal app (fn app)
 
 -- | Use specified middleware only on requests matching path.
 useAt :: forall e. Path -> Handler e -> App e


### PR DESCRIPTION
Some middleware, such as [express-stormpath](https://github.com/stormpath/express-stormpath), decorates the app before becoming middleware. From it's docs: `app.use(stormpath.init(app, { }));`

It's pretty dumb, in my opinion, but it's how express middleware is sometimes written, and I need to use that middleware.

What are your thoughts on adding this?

As an example of how I'm using this, here's my middleware function in my Main.js FFI:

``` javascript
// Main.js
var stormpath = require('express-stormpath');
exports.stormpathWithConfig = function(app) {
  return stormpath.init(app, {
    debug: 'info',
    web: { ... }
  });
}
```

```
foreign import stormpathWithConfig :: forall e. Application -> Fn3 Request Response (ExpressM e Unit) (ExpressM e Unit)

``` purescript
appSetup = do
  useExternal $ static_ "static/dist"
  useExternalWithApp stormpathWithConfig
```

This middleware, then, handles requests to "/login", "/register", "/forgotpassword", etc.