### PR TITLE
Add getProp function to get arbitrary req property.

### DIFF
--- a/src/Node/Express/Request.js
+++ b/src/Node/Express/Request.js
@@ -12,6 +12,12 @@ exports._getRoute = function (req) {
     };
 };
 
+exports._getProp = function (req, key) {
+    return function () {
+        return req[key] == null ? void 0 : req.body;
+    };
+};
+
 exports._getBody = function (req) {
     return function () {
         return req.body == null ? void 0 : req.body;

--- a/src/Node/Express/Request.js
+++ b/src/Node/Express/Request.js
@@ -14,7 +14,7 @@ exports._getRoute = function (req) {
 
 exports._getProp = function (req, key) {
     return function () {
-        return req[key] == null ? void 0 : req.body;
+        return req[key] == null ? void 0 : req[key];
     };
 };
 

--- a/src/Node/Express/Request.purs
+++ b/src/Node/Express/Request.purs
@@ -1,6 +1,6 @@
 module Node.Express.Request
-    ( getRouteParam, getQueryParam, getQueryParams, getBody
-    , getBodyParam, getRoute
+    ( getRouteParam, getQueryParam, getQueryParams, getProp
+    , getBody, getBodyParam, getRoute
     , getCookie, getSignedCookie
     , getRequestHeader
     , accepts, ifAccepts, acceptsCharset, acceptsLanguage, hasType
@@ -33,6 +33,11 @@ import Node.Express.Internal.QueryString (Param, parse, getAll, getOne)
 getRouteParam :: forall e a. (RequestParam a) => a -> HandlerM (express :: EXPRESS | e) (Maybe String)
 getRouteParam name = HandlerM \req _ _ ->
     liftEff $ liftM1 (eitherToMaybe <<< runExcept <<< read) (runFn2 _getRouteParam req name)
+
+-- | Get an arbitrary property from the request object.
+getProp :: forall e a. (IsForeign a) => String -> HandlerM (express :: EXPRESS | e) (Either MultipleErrors a)
+getProp k = HandlerM \req _ _ ->
+    liftEff $ liftM1 (runExcept <<< read) (runFn2 _getProp req k)
 
 -- | Get the request's body.
 -- | NOTE: Not parsed by default, you must attach proper middleware
@@ -192,6 +197,8 @@ queryParams req = do
 foreign import _getRouteParam :: forall e a. Fn2 Request a (ExpressM e Foreign)
 
 foreign import _getRoute :: forall e. Request -> ExpressM e String
+
+foreign import _getProp :: forall e. Fn2 Request String (ExpressM e Foreign)
 
 foreign import _getBody :: forall e. Request -> ExpressM e Foreign
 


### PR DESCRIPTION
The Stormpath middleware is executed on every request to read the session cookie, query the Stormpath database for a Stormpath Account matching the session cookie, then place the Account object on the Express `req` object, as `user` property, for other middlewares to use.

I use it like kinda this:

```
myHandler = do
   bodyData <- getBody
   spa <- lmap (\err -> trace ("user parse errors: " <> show err) \_ -> show err) <$> getProp "user"
   maybe
     sendJson "No user found."
     sendJson $ myLogic <$> bodyData <*> spa
```

What do you think about adding a function like this? Looks like there's no way to get arbitrary properties from the request object right now. Relevant SO article: https://stackoverflow.com/questions/18875292/passing-variables-to-the-next-middleware-using-next-in-expressjs