### PR TITLE
shouldn't need extra cons cell post-compilation

### DIFF
--- a/src/Node/Express/Handler.purs
+++ b/src/Node/Express/Handler.purs
@@ -16,7 +16,7 @@ import Node.Express.Types (EXPRESS, ExpressM, Response, Request)
 import Node.Express.Internal.Utils (nextWithError)
 
 -- | Monad responsible for handling single request.
-data HandlerM e a = HandlerM (Request -> Response -> Eff e Unit -> Aff e a)
+newtype HandlerM e a = HandlerM (Request -> Response -> Eff e Unit -> Aff e a)
 
 type Handler e = HandlerM (express :: EXPRESS | e) Unit
 


### PR DESCRIPTION
The data declaration for HandlerM could be turned into a newtype, but maintain the same semantic behavior I'm pretty sure - purescript is strict by default, and the only way to emulate laziness is with a `Unit -> ...` function.

So _I think_ this change should result in better compiled output code... please let me know if I'm mistaken!