### PR TITLE
add getBody' method for getting the Foreign body content

### DIFF
--- a/src/Node/Express/Request.purs
+++ b/src/Node/Express/Request.purs
@@ -1,5 +1,5 @@
 module Node.Express.Request
-    ( getRouteParam, getQueryParam, getQueryParams, getBody
+    ( getRouteParam, getQueryParam, getQueryParams, getBody, getBody'
     , getBodyParam, getRoute
     , getCookie, getSignedCookie
     , getRequestHeader
@@ -40,6 +40,13 @@ getRouteParam name = HandlerM \req _ _ ->
 getBody :: forall e a. (Decode a) => HandlerM (express :: EXPRESS | e) (Either MultipleErrors a)
 getBody = HandlerM \req _ _ ->
     liftEff $ liftM1 (runExcept <<< decode) (_getBody req)
+
+-- | Get the request's body without a `Decode` parsing.
+-- | NOTE: Not parsed by default, you must attach proper middleware
+-- |       See http://expressjs.com/4x/api.html#req.body
+getBody' :: forall e. HandlerM (express :: EXPRESS | e) Foreign
+getBody' = HandlerM \req _ _ ->
+    liftEff $ _getBody req
 
 -- | Get param from request's body.
 -- | NOTE: Not parsed by default, you must attach proper middleware


### PR DESCRIPTION
fixes #71 

I'm not sure what I should do to go about adding a test though, if needed. `getBody' >>= unsafeStringify >>> setTestHeader` would match the form of the rest but then I'd need to update all the tests because of this value.