### PR TITLE
added new setBody function that takes a foregin object

### DIFF
--- a/src/Node/Express/Test/Mock.purs
+++ b/src/Node/Express/Test/Mock.purs
@@ -5,6 +5,7 @@ module Node.Express.Test.Mock
     , setRequestHeader
     , setRouteParam
     , setBody
+    , setBody'
     , setBodyParam
     , setRequestCookie
     , setRequestSignedCookie
@@ -29,6 +30,8 @@ module Node.Express.Test.Mock
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Reader.Trans
+import Data.Foreign (Foreign)
+import Data.Foreign.Class (encode)
 import Data.Maybe (Maybe)
 import Node.Express.App (App, apply)
 import Node.Express.Handler (Handler)
@@ -57,7 +60,7 @@ type MockResponse =
 
 newtype MockRequest = MockRequest
     { setHeader :: String -> String -> MockRequest
-    , setBody :: String -> MockRequest
+    , setBody :: Foreign -> MockRequest
     , setBodyParam :: String -> String -> MockRequest
     , setRouteParam :: String -> String -> MockRequest
     , setCookie :: String -> String -> MockRequest
@@ -68,7 +71,10 @@ setRequestHeader :: String -> String -> MockRequest -> MockRequest
 setRequestHeader name value (MockRequest r) = r.setHeader name value
 
 setBody :: String -> MockRequest -> MockRequest
-setBody value (MockRequest r) = r.setBody value
+setBody value (MockRequest r) = r.setBody $ encode value
+
+setBody' :: Foreign -> MockRequest -> MockRequest
+setBody' value (MockRequest r) = r.setBody value
 
 setBodyParam :: String -> String -> MockRequest -> MockRequest
 setBodyParam name value (MockRequest r) = r.setBodyParam name value

--- a/test/Test/Handler.purs
+++ b/test/Test/Handler.purs
@@ -8,11 +8,13 @@ import Data.Default
 import Data.Foreign.Class
 import Data.Function
 import Data.Maybe
+import Node.Express.App hiding (apply)
 import Node.Express.Handler
 import Node.Express.Request
 import Node.Express.Response
 import Node.Express.Test.Mock
 import Node.Express.Types
+import Prelude hiding (id)
 import Test.Unit
 import Test.Unit.Assert
 import Test.Unit.Console
@@ -21,11 +23,9 @@ import Unsafe.Coerce
 import Control.Monad.Except (runExcept)
 import Data.Array (head)
 import Data.Either (either)
-import Data.Foreign (readString)
+import Data.Foreign (readString, toForeign)
 import Data.StrMap as StrMap
 import Global.Unsafe (unsafeStringify)
-import Node.Express.App hiding (apply)
-import Prelude hiding (id)
 
 
 foreign import cwdJson :: String
@@ -53,6 +53,7 @@ testParams = do
         setupMockApp $ use paramsHandler
         sendTestRequest withoutParams assertTestHeaderAbsent
         sendTestRequest withBody assertTestHeaderExists
+        sendTestRequest withBody' assertTestHeaderExists
     testExpress "getBodyParam" $ do
         setupMockApp $ use paramsHandler
         sendTestRequest withoutParams assertTestHeaderAbsent
@@ -70,6 +71,7 @@ testParams = do
     withoutParams  = id
     withRouteParam = setRouteParam testParam testValue
     withBody       = setBody       testValue
+    withBody'      = setBody' $ toForeign testValue
     withBodyParam  = setBodyParam  testParam testValue
     urlWithQueryParam = "http://example.com?" <> testParam <> "=" <> testValue
     urlWithQueryParams = urlWithQueryParam <> "&" <> testParam <> "=someOtherValue"


### PR DESCRIPTION
This adds the ability to set foregin values as the body for mock requests.