### PR TITLE
Add missing bower dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,9 @@
   "dependencies": {
     "purescript-foreign": "^5.0.0",
     "purescript-foreign-generic": "^7.0.0",
-    "purescript-node-http": "^5.0.0"
+    "purescript-node-http": "^5.0.0",
+    "purescript-test-unit": "^14.0.0",
+    "purescript-aff": "^5.0.2"
   },
   "devDependencies": {
     "purescript-test-unit": "^14.0.0"

--- a/src/Node/Express/Request.purs
+++ b/src/Node/Express/Request.purs
@@ -15,13 +15,10 @@ import Prelude
 
 import Data.Function.Uncurried (Fn2, Fn3, Fn4, runFn2, runFn3, runFn4)
 import Data.Maybe (Maybe(..), maybe)
-import Data.String (CodePoint, codePointFromChar, drop, dropWhile, null, takeWhile)
-import Data.Array ((:))
 import Effect (Effect)
 import Effect.Class (liftEffect)
 import Foreign (F, Foreign)
 import Foreign.Class (class Decode, decode)
-import Foreign.Object (Object, lookup)
 import Node.Express.Handler (Handler, HandlerM(..))
 import Node.Express.Types (class RequestParam, Request, Method, Protocol, decodeProtocol, decodeMethod)
 


### PR DESCRIPTION
Fix error caused by adding purescript-express as dependency to the project
that itself does not require aff and test-unit
Additionally fix existing compilation warnings.